### PR TITLE
Added order attribute

### DIFF
--- a/includes/class-gs-faq-shortcode.php
+++ b/includes/class-gs-faq-shortcode.php
@@ -38,6 +38,7 @@ class Genesis_Simple_FAQ_Shortcode {
 			'id'    => '',
 			'cat'   => '',
 			'limit' => -1,
+			'order' => 'DESC'
 		), $atts );
 
 		// If IDs are set, use them. Otherwise retrieve all.
@@ -48,6 +49,7 @@ class Genesis_Simple_FAQ_Shortcode {
 
 		$args = array(
 			'orderby'        => 'post__in',
+			'order'			 => $a['order'],
 			'post_type'      => 'gs_faq',
 			'post__in'       => $ids,
 			'posts_per_page' => $a['limit'],


### PR DESCRIPTION
I was looking for a way to order the full list of FAQ displayed when using the `[gs_faq]` general shortcode.

I didn't find it so I decided to add one.

Let me know if you're planning to merge it in a future release.

Thanks for your time and your plugin.