### PR TITLE
Fix Compatibility Notice Text, Version Bump

### DIFF
--- a/genesis-simple-faq.php
+++ b/genesis-simple-faq.php
@@ -8,7 +8,7 @@
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  *
- * Version: 1.0.0
+ * Version: 1.0.1
  *
  * Text Domain: genesis-simple-faq
  * Domain Path: /languages
@@ -19,7 +19,7 @@
  * @package genesis-simple-faq
  */
 
-define( 'GENESIS_SIMPLE_PLUGIN_VERSION', '1.0.0' );
+define( 'GENESIS_SIMPLE_PLUGIN_VERSION', '1.0.1' );
 define( 'GENESIS_SIMPLE_FAQ_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_SIMPLE_FAQ_URL', plugins_url( '', __FILE__ ) );
 

--- a/includes/class-genesis-simple-faq.php
+++ b/includes/class-genesis-simple-faq.php
@@ -126,7 +126,7 @@ final class Genesis_Simple_FAQ {
 
 		if ( ! defined( 'PARENT_THEME_VERSION' ) || ! version_compare( PARENT_THEME_VERSION, $this->min_genesis_version, '>=' ) ) {
 
-			$plugin = get_plugin_data( __FILE__ );
+			$plugin = get_plugin_data( $this->plugin_dir_path . 'genesis-simple-faq.php' );
 
 			$action = defined( 'PARENT_THEME_VERSION' ) ? __( 'upgrade to', 'genesis-simple-faq' ) : __( 'install and activate', 'genesis-simple-faq' );
 

--- a/languages/genesis-simple-faq.pot
+++ b/languages/genesis-simple-faq.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Simple FAQ 1.0.0\n"
+"Project-Id-Version: Genesis Simple FAQ 1.0.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/genesis-simple-faq\n"
-"POT-Creation-Date: 2019-07-02 13:47:59+00:00\n"
+"POT-Creation-Date: 2019-07-31 15:52:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesis-simple-faq",
-  "version": "0.9.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-simple-faq",
   "description": "A simple plugin for the Genesis Framework to manage FAQ components.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/studiopress/genesis-simple-faq"
@@ -19,7 +19,7 @@
     "description": "A simple plugin for the Genesis Framework to manage FAQ components.",
     "author": "StudioPress",
     "authoruri": "https://www.studiopress.com/",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-simple-faq"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: studiopress, calvinkoepke, nathanrice, modernnerd
 Tags: genesis, faq
 Requires at least: 4.8
 Tested up to: 4.8
-Stable tag: 0.9.1
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -131,6 +131,11 @@ function your_custom_function( $template, $question, $answer ) {
 `
 
 == Changelog ==
+
+= 1.0.1 =
+
+* Further testing on more recent versions of WordPress
+* Fix messaging issue when using non-Genesis theme
 
 = 1.0.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: studiopress, calvinkoepke, nathanrice, modernnerd
 Tags: genesis, faq
 Requires at least: 4.8
-Tested up to: 4.8
+Tested up to: 5.2.2
 Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
**Summary of change:**
 - Addresses issue https://github.com/studiopress/genesis-simple-faq/issues/53
 - Version bump to reflect testing with new WordPress versions

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards